### PR TITLE
Feature: Write stamp only when hs state data comes in

### DIFF
--- a/include/ugv_sdk/details/robot_base/agilex_base.hpp
+++ b/include/ugv_sdk/details/robot_base/agilex_base.hpp
@@ -325,7 +325,7 @@ class AgilexBase : public RobotCommonInterface {
 
   void UpdateActuatorState(const AgxMessage &status_msg) {
     std::lock_guard<std::mutex> guard(actuator_state_mtx_);
-    actuator_state_msgs_.time_stamp = SdkClock::now();
+    // actuator_state_msgs_.time_stamp = SdkClock::now();
     switch (status_msg.type) {
       case AgxMsgMotorAngle: {
         actuator_state_msgs_.motor_angles.angle_5 =
@@ -351,6 +351,7 @@ class AgilexBase : public RobotCommonInterface {
       }
       case AgxMsgActuatorHSState: {
         // std::cout << "actuator hs feedback received" << std::endl;
+        actuator_state_msgs_.time_stamp = SdkClock::now();
         actuator_state_msgs_
             .actuator_hs_state[status_msg.body.actuator_hs_state_msg.motor_id] =
             status_msg.body.actuator_hs_state_msg;


### PR DESCRIPTION
### 주요내용
우리는 데이터 중에 encoder 데이터만 사용하기 때문에, encoder 데이터를 받을 때만 stamp를 업데이트하도록 수정했습니다.